### PR TITLE
chore!: update stack resolver to 20.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,9 @@ jobs:
           restore-keys: ${{ runner.os }}-stack-work-
 
       - name: Install system dependencies
-        run: sudo apt-get install libxrandr-dev libxss-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libxrandr-dev libxss-dev
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup GHC with Stack
         uses: haskell/actions/setup@v2
         with:
-          ghc-version: "9.0.2"
+          ghc-version: "9.2.5"
           enable-stack: true
 
       - name: Cache ~/.stack

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: |
           stack update
-          stack build --only-dependencies
+          stack build --only-dependencies --verbosity error
 
       - name: Build
         run: stack build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: |
           stack update
-          stack build --only-dependencies --verbosity error
+          stack build --only-dependencies
 
       - name: Build
         run: stack build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install libxrandr-dev libxss-dev
+          sudo apt-get install libxrandr-dev libxss-dev libxft-dev
 
       - name: Install dependencies
         run: |

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.1
+resolver: lts-20.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.4
+resolver: lts-20.6
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Updated stack resolver to 20.6.
Updated CI ghc version to 9.2.5.
Changed CI build script to update `apt-get` database before installing system dependencies.
Added `libxft-dev` as system dependency for CI.